### PR TITLE
use OR(<<, >>) for all rotations

### DIFF
--- a/blake2b-common.h
+++ b/blake2b-common.h
@@ -27,12 +27,6 @@ static INLINE uint64_t LOADU64(void const * p) {
   return v;
 }
 
-#define ROTATE16 _mm256_setr_epi8( 2, 3, 4, 5, 6, 7, 0, 1, 10, 11, 12, 13, 14, 15, 8, 9, \
-                                   2, 3, 4, 5, 6, 7, 0, 1, 10, 11, 12, 13, 14, 15, 8, 9 )
-
-#define ROTATE24 _mm256_setr_epi8( 3, 4, 5, 6, 7, 0, 1, 2, 11, 12, 13, 14, 15, 8, 9, 10, \
-                                   3, 4, 5, 6, 7, 0, 1, 2, 11, 12, 13, 14, 15, 8, 9, 10 )
-
 #define ADD(a, b) _mm256_add_epi64(a, b)
 #define SUB(a, b) _mm256_sub_epi64(a, b)
 
@@ -40,9 +34,9 @@ static INLINE uint64_t LOADU64(void const * p) {
 #define AND(a, b) _mm256_and_si256(a, b)
 #define  OR(a, b) _mm256_or_si256(a, b)
 
-#define ROT32(x) _mm256_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))
-#define ROT24(x) _mm256_shuffle_epi8((x), ROTATE24)
-#define ROT16(x) _mm256_shuffle_epi8((x), ROTATE16)
-#define ROT63(x) _mm256_or_si256(_mm256_srli_epi64((x), 63), ADD((x), (x)))
+#define ROT32(x) _mm256_or_si256(_mm256_srli_epi64((x), 32), _mm256_slli_epi64((x), 64 -32))
+#define ROT24(x) _mm256_or_si256(_mm256_srli_epi64((x), 24), _mm256_slli_epi64((x), 64 -24))
+#define ROT16(x) _mm256_or_si256(_mm256_srli_epi64((x), 16), _mm256_slli_epi64((x), 64 -16))
+#define ROT63(x) _mm256_or_si256(_mm256_srli_epi64((x), 63), _mm256_slli_epi64((x), 64 -63))
 
 #endif

--- a/blake2s-common.h
+++ b/blake2s-common.h
@@ -24,11 +24,6 @@ static INLINE uint32_t LOADU32(void const * p) {
 #define TOF(reg) _mm_castsi128_ps((reg))
 #define TOI(reg) _mm_castps_si128((reg))
 
-#define ROTATE8128  _mm_set_epi8(12, 15, 14, 13, 8, 11, 10, 9, 4, 7, 6, 5, 0, 3, 2, 1)
-
-#define ROTATE16128 _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2)
-
-
 #define ADD128(a, b) _mm_add_epi32(a, b)
 #define SUB128(a, b) _mm_sub_epi32(a, b)
 
@@ -36,22 +31,16 @@ static INLINE uint32_t LOADU32(void const * p) {
 #define AND128(a, b) _mm_and_si128(a, b)
 #define  OR128(a, b) _mm_or_si128(a, b)
 
-#define ROT16128(x) _mm_shuffle_epi8((x), ROTATE16128)
-#define ROT12128(x) OR128(_mm_srli_epi32((x), 12), _mm_slli_epi32((x), 20))
-#define ROT8128(x)  _mm_shuffle_epi8((x), ROTATE8128)
-#define ROT7128(x)  OR128(_mm_srli_epi32((x),  7), _mm_slli_epi32((x), 25))
+#define ROT16128(x)  OR128(_mm_srli_epi32((x),  16), _mm_slli_epi32((x), 32 - 16))
+#define ROT12128(x)  OR128(_mm_srli_epi32((x),  12), _mm_slli_epi32((x), 32 - 12))
+#define ROT8128(x)  OR128(_mm_srli_epi32((x),  8), _mm_slli_epi32((x), 32 - 8))
+#define ROT7128(x)  OR128(_mm_srli_epi32((x),  7), _mm_slli_epi32((x), 32 - 7))
 
 #define LOAD(p)  _mm256_load_si256( (__m256i *)(p) )
 #define STORE(p,r) _mm256_store_si256((__m256i *)(p), r)
 
 #define LOADU(p)  _mm256_loadu_si256( (__m256i *)(p) )
 #define STOREU(p,r) _mm256_storeu_si256((__m256i *)(p), r)
-
-#define ROTATE8  _mm256_set_epi8(12, 15, 14, 13, 8, 11, 10, 9, 4, 7, 6, 5, 0, 3, 2, 1, \
-                                 12, 15, 14, 13, 8, 11, 10, 9, 4, 7, 6, 5, 0, 3, 2, 1)
-
-#define ROTATE16 _mm256_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2, \
-                                 13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2)
 
 #define ADD(a, b) _mm256_add_epi32(a, b)
 #define SUB(a, b) _mm256_sub_epi32(a, b)
@@ -60,9 +49,9 @@ static INLINE uint32_t LOADU32(void const * p) {
 #define AND(a, b) _mm256_and_si256(a, b)
 #define  OR(a, b) _mm256_or_si256(a, b)
 
-#define ROT16(x) _mm256_shuffle_epi8((x), ROTATE16)
-#define ROT12(x) _mm256_or_si256(_mm256_srli_epi32((x), 12), _mm256_slli_epi32((x), 20))
-#define ROT8(x)  _mm256_shuffle_epi8((x), ROTATE8)
-#define ROT7(x)  _mm256_or_si256(_mm256_srli_epi32((x),  7), _mm256_slli_epi32((x), 25))
+#define ROT16(x)  _mm256_or_si256(_mm256_srli_epi32((x),  16), _mm256_slli_epi32((x), 32 - 16))
+#define ROT12(x)  _mm256_or_si256(_mm256_srli_epi32((x),  12), _mm256_slli_epi32((x), 32 - 12))
+#define ROT8(x)  _mm256_or_si256(_mm256_srli_epi32((x),  8), _mm256_slli_epi32((x), 32 - 8))
+#define ROT7(x)  _mm256_or_si256(_mm256_srli_epi32((x),  7), _mm256_slli_epi32((x), 32 - 7))
 
 #endif


### PR DESCRIPTION
Discussion/experiment PR: I was playing around with different rotations, and I found that these simplified ones seem to perform a lot better under Clang/Rustc. Most of the functions improve by about 6%, but BLAKE2b improves by 14%. Have you run into this before? Is it a known Clang vs GCC thing?